### PR TITLE
Fix DemoArea buttons property

### DIFF
--- a/src/common/demo-area.html
+++ b/src/common/demo-area.html
@@ -90,7 +90,7 @@
       static get properties() {
         return {
             buttons: {
-              value: [],
+              value: () =>[],
               type: Object
             },
             modes: {


### PR DESCRIPTION
It should be a function that returns an array to prevent all
DemoArea instances to share the same array reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-board-demo/52)
<!-- Reviewable:end -->
